### PR TITLE
Ad cow lots sell functionality

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -127,7 +127,14 @@ public class UserCommonsController extends ApiController {
 
 
         if(userCommons.getNumOfCows() >= 1 ){
-          userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice());
+          CowLot lot = cowLotRepository.findTopByUserCommonsIdOrderByHealthDesc(userCommons.getId());
+          lot.setNumCows(lot.getNumCows() - 1);
+          if(lot.getNumCows() == 0){
+            cowLotRepository.delete(lot);
+          } else {
+            cowLotRepository.save(lot);
+          }
+          userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice()*lot.getHealth()/100);
           userCommons.setNumOfCows(userCommons.getNumOfCows() - 1);
         }
         else{

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowLotRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowLotRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CowLotRepository extends CrudRepository<CowLot, Long> {
     Iterable<CowLot> findAllByUserCommonsId(Long userCommonsId);
+    CowLot findTopByUserCommonsIdOrderByHealthDesc(Long userCommonsId);
 }


### PR DESCRIPTION
Finishes #45 

In this PR userCommonsController selling functionality is augmented to sell from CowLots also, by taking the highest health cow a user has, then giving money proportional to that. The entity is deleted once it hits 0 cows, and otherwise is updated in the repository.