### PR TITLE
Ad cow lots optimization to combine lots

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -127,7 +127,14 @@ public class UserCommonsController extends ApiController {
 
 
         if(userCommons.getNumOfCows() >= 1 ){
-          userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice());
+          CowLot lot = cowLotRepository.findTopByUserCommonsIdOrderByHealthDesc(userCommons.getId());
+          lot.setNumCows(lot.getNumCows() - 1);
+          if(lot.getNumCows() == 0){
+            cowLotRepository.delete(lot);
+          } else {
+            cowLotRepository.save(lot);
+          }
+          userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice()*lot.getHealth()/100);
           userCommons.setNumOfCows(userCommons.getNumOfCows() - 1);
         }
         else{

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -33,6 +33,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.Optional;
+
 @Api(description = "User Commons")
 @RequestMapping("/api/usercommons")
 @RestController
@@ -95,12 +97,21 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getTotalWealth() >= commons.getCowPrice() ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice());
           userCommons.setNumOfCows(userCommons.getNumOfCows() + 1);
-          CowLot lot = CowLot.builder()
-            .userCommonsId(userCommons.getId())
-            .numCows(1)
-            .health(100d)
-            .build();
-          cowLotRepository.save(lot);
+          Optional<CowLot> existingCowLotOptional = cowLotRepository.findByUserCommonsIdAndHealth(
+                                                      userCommons.getId(),
+                                                      100d);
+          if(existingCowLotOptional.isPresent()){
+            CowLot existingCowLot = existingCowLotOptional.get();
+            existingCowLot.setNumCows(existingCowLot.getNumCows()+1);
+            cowLotRepository.save(existingCowLot);
+          } else {
+            CowLot lot = CowLot.builder()
+              .userCommonsId(userCommons.getId())
+              .numCows(1)
+              .health(100d)
+              .build();
+            cowLotRepository.save(lot);
+          }
         }
         else{
           throw new NotEnoughMoneyException("You need more money!");

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CowLot.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CowLot.java
@@ -17,7 +17,7 @@ public class CowLot {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
+    
     private long userCommonsId;
     private int numCows;
     private double health;

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowLotRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowLotRepository.java
@@ -3,8 +3,10 @@ package edu.ucsb.cs156.happiercows.repositories;
 import edu.ucsb.cs156.happiercows.entities.CowLot;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 @Repository
 public interface CowLotRepository extends CrudRepository<CowLot, Long> {
     Iterable<CowLot> findAllByUserCommonsId(Long userCommonsId);
+    Optional<CowLot> findByUserCommonsIdAndHealth(Long userCommonsId, Double Health);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowLotRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowLotRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CowLotRepository extends CrudRepository<CowLot, Long> {
     Iterable<CowLot> findAllByUserCommonsId(Long userCommonsId);
+    CowLot findTopByUserCommonsIdOrderByHealthDesc(Long userCommonsId);
 }


### PR DESCRIPTION
Finishes #47 
Relies on PR #46 

This pull requests adds the optimization of not creating new cow lots if a cow lot exists that has the same health for the target user.