### PR TITLE
added deg rate to admin commons toast

### DIFF
--- a/frontend/src/main/pages/AdminCreateCommonsPage.js
+++ b/frontend/src/main/pages/AdminCreateCommonsPage.js
@@ -21,6 +21,7 @@ const AdminCreateCommonsPage = () => {
             <br />{`startDate: ${commons.startingDate}`}
             <br />{`cowPrice: ${commons.cowPrice}`}
             <br />{`carryingCapacity: ${commons.carryingCapacity}`}
+            <br />{`degradationRate: ${commons.degradationRate}`}
         </div>);
     }
    

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -119,6 +119,7 @@ describe("AdminCreateCommonsPage tests", () => {
             <br />startDate: 2022-03-05T00:00:00
             <br />cowPrice: 10
             <br />carryingCapacity: 25
+            <br />degradationRate: 30.4
         </div>);
     });
 });


### PR DESCRIPTION
Minor change to toast notification when user commons is created by admin so that it also displays chosen degradation rate.