### PR TITLE
Implement cowlots into health degredation job

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -127,7 +127,14 @@ public class UserCommonsController extends ApiController {
 
 
         if(userCommons.getNumOfCows() >= 1 ){
-          userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice());
+          CowLot lot = cowLotRepository.findTopByUserCommonsIdOrderByHealthDesc(userCommons.getId());
+          lot.setNumCows(lot.getNumCows() - 1);
+          if(lot.getNumCows() == 0){
+            cowLotRepository.delete(lot);
+          } else {
+            cowLotRepository.save(lot);
+          }
+          userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice()*lot.getHealth()/100);
           userCommons.setNumOfCows(userCommons.getNumOfCows() - 1);
         }
         else{

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -33,6 +33,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.Optional;
+
 @Api(description = "User Commons")
 @RequestMapping("/api/usercommons")
 @RestController
@@ -95,12 +97,21 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getTotalWealth() >= commons.getCowPrice() ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice());
           userCommons.setNumOfCows(userCommons.getNumOfCows() + 1);
-          CowLot lot = CowLot.builder()
-            .userCommonsId(userCommons.getId())
-            .numCows(1)
-            .health(100d)
-            .build();
-          cowLotRepository.save(lot);
+          Optional<CowLot> existingCowLotOptional = cowLotRepository.findByUserCommonsIdAndHealth(
+                                                      userCommons.getId(),
+                                                      100d);
+          if(existingCowLotOptional.isPresent()){
+            CowLot existingCowLot = existingCowLotOptional.get();
+            existingCowLot.setNumCows(existingCowLot.getNumCows()+1);
+            cowLotRepository.save(existingCowLot);
+          } else {
+            CowLot lot = CowLot.builder()
+              .userCommonsId(userCommons.getId())
+              .numCows(1)
+              .health(100d)
+              .build();
+            cowLotRepository.save(lot);
+          }
         }
         else{
           throw new NotEnoughMoneyException("You need more money!");

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CowLot.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CowLot.java
@@ -17,7 +17,7 @@ public class CowLot {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
+    
     private long userCommonsId;
     private int numCows;
     private double health;

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -9,10 +9,12 @@ import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
+import edu.ucsb.cs156.happiercows.entities.CowLot;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.repositories.CowLotRepository;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.AllArgsConstructor;
@@ -24,6 +26,8 @@ public class UpdateCowHealthJob implements JobContextConsumer {
     private CommonsRepository commonsRepository;
     @Getter
     private UserCommonsRepository userCommonsRepository;
+    @Getter
+    private CowLotRepository cowLotRepository;
     @Getter
     private UserRepository userRepository;
 
@@ -41,14 +45,18 @@ public class UpdateCowHealthJob implements JobContextConsumer {
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
 
             Integer totalCows = commonsRepository.getNumCows(commons.getId()).orElseThrow(()->new RuntimeException("Error calling getNumCows(" + commons.getId() + ")"));
-
             for (UserCommons userCommons : allUserCommons) {
+                double totalHealths = 0d;
                 User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling userRepository.findById(" + userCommons.getUserId() + ")"));
                 ctx.log("User: " + user.getFullName() + ", numCows: " + userCommons.getNumOfCows() + ", cowHealth: " + userCommons.getCowHealth());
-
-                double newCowHealth = calculateNewCowHealth(userCommons.getCowHealth(), userCommons.getNumOfCows(), totalCows, carryingCapacity, degradationRate);
-                ctx.log(" old cow health: " + userCommons.getCowHealth() + ", new cow health: " + newCowHealth);
-                userCommons.setCowHealth(newCowHealth);
+                for(CowLot cowLot: cowLotRepository.findAllByUserCommonsId(userCommons.getId())){
+                    double newCowHealth = calculateNewCowHealth(cowLot.getHealth(), userCommons.getNumOfCows(), totalCows, carryingCapacity, degradationRate);
+                    ctx.log(" old cow health: " + cowLot.getHealth() + ", new cow health: " + newCowHealth);
+                    cowLot.setHealth(newCowHealth);
+                    cowLotRepository.save(cowLot);
+                    totalHealths += newCowHealth * cowLot.getNumCows();
+                }
+                userCommons.setCowHealth(totalHealths / userCommons.getNumOfCows());
                 userCommonsRepository.save(userCommons);
             }
         }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.repositories.CowLotRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,11 +22,14 @@ public class UpdateCowHealthJobFactory  {
     private UserCommonsRepository userCommonsRepository;
 
     @Autowired
+    private CowLotRepository cowLotRepository;
+
+    @Autowired
     private UserRepository userRepository;
 
     public JobContextConsumer create() {
         log.info("commonsRepository = " + commonsRepository);
         log.info("userCommonsRepository = " + userCommonsRepository);
-        return new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
+        return new UpdateCowHealthJob(commonsRepository, userCommonsRepository, cowLotRepository, userRepository);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowLotRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowLotRepository.java
@@ -3,8 +3,10 @@ package edu.ucsb.cs156.happiercows.repositories;
 import edu.ucsb.cs156.happiercows.entities.CowLot;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 @Repository
 public interface CowLotRepository extends CrudRepository<CowLot, Long> {
     Iterable<CowLot> findAllByUserCommonsId(Long userCommonsId);
+    Optional<CowLot> findByUserCommonsIdAndHealth(Long userCommonsId, Double Health);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowLotRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowLotRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CowLotRepository extends CrudRepository<CowLot, Long> {
     Iterable<CowLot> findAllByUserCommonsId(Long userCommonsId);
+    CowLot findTopByUserCommonsIdOrderByHealthDesc(Long userCommonsId);
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -3,8 +3,7 @@ package edu.ucsb.cs156.happiercows.jobs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.Optional;
+import java.util.*;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,9 +17,11 @@ import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.repositories.CowLotRepository;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.CowLot;
 
 import java.time.LocalDateTime;
 
@@ -35,6 +36,9 @@ public class UpdateCowHealthJobTests {
 
         @Mock
         UserRepository userRepository;
+
+        @Mock
+        CowLotRepository cowLotRepository;
 
         private User user = User
                         .builder()
@@ -53,7 +57,7 @@ public class UpdateCowHealthJobTests {
 
                 // Act
                 UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
+                                cowLotRepository, userRepository);
                 updateCowHealthJob.accept(ctx);
 
                 // Assert
@@ -102,6 +106,14 @@ public class UpdateCowHealthJobTests {
                                 .cowHealth(10.01)
                                 .build();
 
+                CowLot origCowLot = CowLot
+                                .builder()
+                                .id(0L)
+                                .userCommonsId(origUserCommons.getId())
+                                .numCows(1)
+                                .health(10)
+                                .build();
+
                 Commons commonsTemp[] = { testCommons };
                 UserCommons userCommonsTemp[] = { origUserCommons };
                 when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
@@ -109,10 +121,12 @@ public class UpdateCowHealthJobTests {
                                 .thenReturn(Arrays.asList(userCommonsTemp));
                 when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+                when(cowLotRepository.findAllByUserCommonsId(origUserCommons.getId()))
+                        .thenReturn(Collections.singletonList(origCowLot));
 
                 // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
+                                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                cowLotRepository, userRepository);
                 updateCowHealthJob.accept(ctx);
 
                 // Assert
@@ -165,6 +179,13 @@ public class UpdateCowHealthJobTests {
                                 .numOfCows(101)
                                 .cowHealth(99.99)
                                 .build();
+                CowLot origCowLot = CowLot
+                                .builder()
+                                .id(0L)
+                                .userCommonsId(origUserCommons.getId())
+                                .numCows(101)
+                                .health(100)
+                                .build();
 
                 Commons commonsTemp[] = { testCommons };
                 UserCommons userCommonsTemp[] = { origUserCommons };
@@ -173,10 +194,11 @@ public class UpdateCowHealthJobTests {
                                 .thenReturn(Arrays.asList(userCommonsTemp));
                 when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(101)));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
+                when(cowLotRepository.findAllByUserCommonsId(origUserCommons.getId()))
+                        .thenReturn(Collections.singletonList(origCowLot));
                 // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
+                                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                cowLotRepository, userRepository);
                 updateCowHealthJob.accept(ctx);
 
                 // Assert
@@ -229,6 +251,13 @@ public class UpdateCowHealthJobTests {
                                 .numOfCows(100)
                                 .cowHealth(50.01)
                                 .build();
+                CowLot origCowLot = CowLot
+                                .builder()
+                                .id(0L)
+                                .userCommonsId(origUserCommons.getId())
+                                .numCows(100)
+                                .health(50)
+                                .build();
 
                 Commons commonsTemp[] = { testCommons };
                 UserCommons userCommonsTemp[] = { origUserCommons };
@@ -237,10 +266,12 @@ public class UpdateCowHealthJobTests {
                                 .thenReturn(Arrays.asList(userCommonsTemp));
                 when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(100)));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+                when(cowLotRepository.findAllByUserCommonsId(origUserCommons.getId()))
+                        .thenReturn(Collections.singletonList(origCowLot));
 
                 // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
+                                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                cowLotRepository, userRepository);
                 updateCowHealthJob.accept(ctx);
 
                 // Assert
@@ -293,6 +324,13 @@ public class UpdateCowHealthJobTests {
                                 .numOfCows(150)
                                 .cowHealth(0)
                                 .build();
+                CowLot origCowLot = CowLot
+                                .builder()
+                                .id(0L)
+                                .userCommonsId(origUserCommons.getId())
+                                .numCows(150)
+                                .health(0)
+                                .build();
 
                 Commons commonsTemp[] = { testCommons };
                 UserCommons userCommonsTemp[] = { origUserCommons };
@@ -301,10 +339,12 @@ public class UpdateCowHealthJobTests {
                                 .thenReturn(Arrays.asList(userCommonsTemp));
                 when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(150)));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+                when(cowLotRepository.findAllByUserCommonsId(origUserCommons.getId()))
+                        .thenReturn(Collections.singletonList(origCowLot));
 
                 // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
+                                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                cowLotRepository, userRepository);
                 updateCowHealthJob.accept(ctx);
 
                 // Assert
@@ -357,6 +397,13 @@ public class UpdateCowHealthJobTests {
                                 .numOfCows(1)
                                 .cowHealth(100)
                                 .build();
+                CowLot origCowLot = CowLot
+                                .builder()
+                                .id(0L)
+                                .userCommonsId(origUserCommons.getId())
+                                .numCows(1)
+                                .health(100)
+                                .build();
 
                 Commons commonsTemp[] = { testCommons };
                 UserCommons userCommonsTemp[] = { origUserCommons };
@@ -365,10 +412,11 @@ public class UpdateCowHealthJobTests {
                                 .thenReturn(Arrays.asList(userCommonsTemp));
                 when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
+                when(cowLotRepository.findAllByUserCommonsId(origUserCommons.getId()))
+                        .thenReturn(Collections.singletonList(origCowLot));
                 // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
+                                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                cowLotRepository, userRepository);
                 updateCowHealthJob.accept(ctx);
 
                 // Assert
@@ -403,7 +451,7 @@ public class UpdateCowHealthJobTests {
 
                 UserCommons origUserCommons2 = UserCommons
                                 .builder()
-                                .id(1L)
+                                .id(2L)
                                 .userId(1L)
                                 .commonsId(1L)
                                 .totalWealth(300)
@@ -413,7 +461,7 @@ public class UpdateCowHealthJobTests {
 
                 UserCommons origUserCommons3 = UserCommons
                                 .builder()
-                                .id(1L)
+                                .id(3L)
                                 .userId(1L)
                                 .commonsId(1L)
                                 .totalWealth(300)
@@ -434,12 +482,34 @@ public class UpdateCowHealthJobTests {
 
                 UserCommons newUserCommons = UserCommons
                                 .builder()
-                                .id(1L)
+                                .id(4L)
                                 .userId(1L)
                                 .commonsId(1L)
                                 .totalWealth(300 - testCommons.getCowPrice())
                                 .numOfCows(5)
                                 .cowHealth(50.01)
+                                .build();
+                
+                CowLot origCowLot1 = CowLot
+                                .builder()
+                                .id(0L)
+                                .userCommonsId(origUserCommons1.getId())
+                                .numCows(5)
+                                .health(50)
+                                .build();
+                CowLot origCowLot2 = CowLot
+                                .builder()
+                                .id(1L)
+                                .userCommonsId(origUserCommons2.getId())
+                                .numCows(5)
+                                .health(50)
+                                .build();
+                CowLot origCowLot3 = CowLot
+                                .builder()
+                                .id(2L)
+                                .userCommonsId(origUserCommons3.getId())
+                                .numCows(5)
+                                .health(50)
                                 .build();
 
                 Commons commonsTemp[] = { testCommons };
@@ -449,10 +519,16 @@ public class UpdateCowHealthJobTests {
                                 .thenReturn(Arrays.asList(userCommonsTemp));
                 when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+                when(cowLotRepository.findAllByUserCommonsId(origUserCommons1.getId()))
+                        .thenReturn(Collections.singletonList(origCowLot1));
+                when(cowLotRepository.findAllByUserCommonsId(origUserCommons2.getId()))
+                        .thenReturn(Collections.singletonList(origCowLot2));
+                when(cowLotRepository.findAllByUserCommonsId(origUserCommons3.getId()))
+                        .thenReturn(Collections.singletonList(origCowLot3));
 
                 // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
+                                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                cowLotRepository, userRepository);
                 updateCowHealthJob.accept(ctx);
 
                 // Assert
@@ -513,7 +589,7 @@ public class UpdateCowHealthJobTests {
 
                 // Act
                 UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
+                                cowLotRepository, userRepository);
 
                 RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
                         // Code under test
@@ -563,7 +639,7 @@ public class UpdateCowHealthJobTests {
 
                 // Act
                 UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                                userRepository);
+                                cowLotRepository, userRepository);
 
                 RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
                         // Code under test

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -8,6 +8,8 @@ import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import org.mockito.Mock;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -114,6 +116,14 @@ public class UpdateCowHealthJobTests {
                                 .health(10)
                                 .build();
 
+                CowLot newCowLot = CowLot
+                                .builder()
+                                .id(0L)
+                                .userCommonsId(origUserCommons.getId())
+                                .numCows(1)
+                                .health(10.01)
+                                .build();
+
                 Commons commonsTemp[] = { testCommons };
                 UserCommons userCommonsTemp[] = { origUserCommons };
                 when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
@@ -137,7 +147,7 @@ public class UpdateCowHealthJobTests {
                                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
                                  old cow health: 10.0, new cow health: 10.01
                                 Cow health has been updated!""";
-
+                verify(cowLotRepository, times(1)).save(newCowLot);
                 assertEquals(expected, jobStarted.getLog());
                 assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
         }


### PR DESCRIPTION
Finishes #50 
Builds off PR #48  and #46 

This pull request updates the updateCowHealth job to use the CowLots for each user to update each health individually, along with being backwards compatible.