### PR TITLE
EP - Counter of Days Elapsed since Start of Commons

### DIFF
--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Row, Card, Col, Button } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
+import { daysElapsed } from "main/utils/commonsUtils";
 import { hasRole } from "main/utils/currentUser";
 
 export default function CommonsOverview({ commons, currentUser }) {

--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -15,8 +15,7 @@ export default function CommonsOverview({ commons, currentUser }) {
             <Card.Body>
                 <Row>
                     <Col>
-                        <Card.Title>Today is day {commons.day}! </Card.Title>
-                        <Card.Text>Total Players: {commons.totalPlayers}</Card.Text>
+                        <Card.Title>Today is Day: {daysElapsed(commons.startingDate, Date.now())} </Card.Title>
                     </Col>
                     <Col>
                         {showLeaderboard &&

--- a/frontend/src/main/utils/commonsUtils.js
+++ b/frontend/src/main/utils/commonsUtils.js
@@ -14,3 +14,10 @@ export function cellToAxiosParamsDelete(cell) {
         }
     }
 }
+
+export function daysElapsed(start, end){
+    let startTime = new Date(start).getTime();
+    let endTime = new Date(end).getTime();
+    var diff = Math.round((endTime - startTime)/(86400000));
+    return (diff > 0)? diff : 0;
+}

--- a/frontend/src/tests/utils/commonsUtil.test.js
+++ b/frontend/src/tests/utils/commonsUtil.test.js
@@ -1,4 +1,4 @@
-import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/commonsUtils";
+import { cellToAxiosParamsDelete, onDeleteSuccess, daysElapsed } from "main/utils/commonsUtils";
 import mockConsole from "jest-mock-console";
 
 const mockToast = jest.fn();
@@ -46,4 +46,25 @@ describe("CommonsUtils", () => {
             });
         });
     });
+
+    describe("daysElapsed test", () => {
+        test("Difference between 2 dates", () => {
+           var startingDate = "2023-05-05T00:00:00";
+           var lastDate = "2023-05-09T21:40:00";
+          expect(daysElapsed(startingDate,lastDate)).toBe(5);
+        });
+    
+        test("Difference between 2 times on same day", () => {
+           var startingDate = "2023-05-05T00:00:00";
+           var lastDate = "2023-05-05T21:40:00";
+          expect(daysElapsed(startingDate,lastDate)).toBe(1);
+        });
+    
+        test("Negative days checker", () => {
+           var startingDate = "2023-05-05T00:30:00";
+           var lastDate = "2023-05-04T21:40:00";
+          expect(daysElapsed(startingDate,lastDate)).toBe(0);
+        });
+    
+      });
 });

--- a/frontend/src/tests/utils/dateUtils.test.js
+++ b/frontend/src/tests/utils/dateUtils.test.js
@@ -25,4 +25,24 @@ describe("dateUtils tests", () => {
     });
   });
 
+  describe("daysElapsed test", () => {
+    test("Difference between 2 dates", () => {
+      const startingDate = "2023-05-05T00:00:00";
+      const lastDate = "2023-05-09T21:40:00";
+      expect(daysElapsed(startingDate,lastDate)).toBe(4);
+    });
+
+    test("Difference between 2 times on same day", () => {
+      const startingDate = "2023-05-05T00:00:00";
+      const lastDate = "2023-05-05T21:40:00";
+      expect(daysElapsed(startingDate,lastDate)).toBe(0);
+    });
+
+    test("Negative days checker", () => {
+      const startingDate = "2023-05-05T00:30:00";
+      const lastDate = "2023-05-04T21:40:00";
+      expect(daysElapsed(startingDate,lastDate)).toBe(0);
+    });
+
+  });
 });

--- a/frontend/src/tests/utils/dateUtils.test.js
+++ b/frontend/src/tests/utils/dateUtils.test.js
@@ -24,25 +24,4 @@ describe("dateUtils tests", () => {
       expect(timestampToDate(1653346250816)).toBe("2022-05-23");
     });
   });
-
-  describe("daysElapsed test", () => {
-    test("Difference between 2 dates", () => {
-      const startingDate = "2023-05-05T00:00:00";
-      const lastDate = "2023-05-09T21:40:00";
-      expect(daysElapsed(startingDate,lastDate)).toBe(4);
-    });
-
-    test("Difference between 2 times on same day", () => {
-      const startingDate = "2023-05-05T00:00:00";
-      const lastDate = "2023-05-05T21:40:00";
-      expect(daysElapsed(startingDate,lastDate)).toBe(0);
-    });
-
-    test("Negative days checker", () => {
-      const startingDate = "2023-05-05T00:30:00";
-      const lastDate = "2023-05-04T21:40:00";
-      expect(daysElapsed(startingDate,lastDate)).toBe(0);
-    });
-
-  });
 });


### PR DESCRIPTION
In this PR, we added an accurate counter to the "Announcements" card on a user's commons (commonsOverview) to accurately display the number of days since the commons was created. We did so by adding an extra function to CommonsUtils to calculate the difference between the current time and the timestamp the admin provides as the start date for the commons. Added tests to commonsUtilTests as well.

Previously:
<img width="652" alt="Screenshot 2023-06-05 at 4 54 35 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-3/assets/21165612/73901d6e-8861-43d7-ab6c-f4206a31e2c2">


Currently: 
<img width="850" alt="Screenshot 2023-06-05 at 7 26 34 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-3/assets/21165612/34268697-596c-4b86-9105-ab731f5ca319">

Storybook:
Before: https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-3/storybook/?path=/story/components-commons-commonsoverview--uncontrolled
After: https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-3/prs/55/storybook/?path=/story/components-commons-commonsoverview--uncontrolled

