### PR TITLE
FEATURE: Added end date to UserCommons and Commons, tests for end date

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -12,7 +12,9 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
 
     const testid = "CommonsForm";
 
-    const today = new Date().toISOString().substr(0, 10);
+    const curr = new Date();
+    const today = curr.toISOString().substr(0, 10);
+    const onemonthfromtoday = new Date(curr.getFullYear(), curr.getMonth()+1, curr.getDate()).toISOString().substr(0, 10);
 
     return (
         <Form onSubmit={handleSubmit(submitAction)}>
@@ -158,6 +160,27 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
                 />
                 <Form.Control.Feedback type="invalid">
                     {errors.startingDate?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+                <Form.Label htmlFor="lastDate">Last Date</Form.Label>
+                <Form.Control
+                    data-testid={`${testid}-lastDate`}
+                    id="lastDate"
+                    type="date"
+                    defaultValue={onemonthfromtoday}
+                    isInvalid={!!errors.lastDate}
+                    {...register("lastDate", {
+                        valueAsDate: true,
+                        validate: {
+                            isPresent: (v) =>
+                                !isNaN(v) || "Last date is required",
+                        },
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.lastDate?.message}
                 </Form.Control.Feedback>
             </Form.Group>
 

--- a/frontend/src/main/pages/AdminCreateCommonsPage.js
+++ b/frontend/src/main/pages/AdminCreateCommonsPage.js
@@ -18,7 +18,8 @@ const AdminCreateCommonsPage = () => {
         toast(<div>Commons successfully created!
             <br />{`id: ${commons.id}`}
             <br />{`name: ${commons.name}`}
-            <br />{`startDate: ${commons.startingDate}`}
+            <br />{`startingDate: ${commons.startingDate}`}
+            <br />{`lastDate: ${commons.lastDate}`}
             <br />{`cowPrice: ${commons.cowPrice}`}
             <br />{`carryingCapacity: ${commons.carryingCapacity}`}
         </div>);

--- a/frontend/src/main/pages/AdminEditCommonsPage.js
+++ b/frontend/src/main/pages/AdminEditCommonsPage.js
@@ -34,6 +34,7 @@ export default function CommonsEditPage() {
         "cowPrice": commons.cowPrice,
         "milkPrice": commons.milkPrice,
         "startingDate": commons.startingDate,
+        "lastDate": commons.lastDate,
         "degradationRate": commons.degradationRate,
         "carryingCapacity": commons.carryingCapacity,
         "showLeaderboard": commons.showLeaderboard,
@@ -72,4 +73,3 @@ export default function CommonsEditPage() {
     </BasicLayout>
   )
 }
-

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -24,6 +24,7 @@ describe("CommonsForm tests", () => {
             /Cow Price/,
             /Milk Price/,
             /Starting Date/,
+            /Last Date/,
             /Degradation Rate/,
             /Carrying Capacity/,
             /Show Leaderboard\?/,
@@ -55,6 +56,10 @@ describe("CommonsForm tests", () => {
             "CommonsForm-startingDate"
         );
         fireEvent.change(startingDateInput, { target: { value: "" } });
+        const lastDateInput = screen.getByTestId(
+            "CommonsForm-lastDate"
+        );
+        fireEvent.change(lastDateInput, { target: { value: "" } });
         const degradationRateInput = screen.getByTestId(
             "CommonsForm-degradationRate"
         );
@@ -85,6 +90,9 @@ describe("CommonsForm tests", () => {
         expect(screen.getByText(/milk price is required/i)).toBeInTheDocument();
         expect(
             screen.getByText(/starting date is required/i)
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/last date is required/i)
         ).toBeInTheDocument();
         expect(
             screen.getByText(/degradation rate is required/i)

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -66,6 +66,7 @@ describe("AdminCreateCommonsPage tests", () => {
             milkPrice: 5,
             startingBalance: 500,
             startingDate: "2022-03-05T00:00:00",
+            lastDate: "3000-01-01T00:00:00",
             degradationRate: 30.4,
             carryingCapacity: 25,
             showLeaderboard: false,
@@ -86,6 +87,7 @@ describe("AdminCreateCommonsPage tests", () => {
         const cowPriceField = screen.getByLabelText("Cow Price");
         const milkPriceField = screen.getByLabelText("Milk Price");
         const startDateField = screen.getByLabelText("Starting Date");
+        const lastDateField = screen.getByLabelText("Last Date");
         const degradationRateField = screen.getByLabelText("Degradation Rate");
         const carryingCapacityField =
             screen.getByLabelText("Carrying Capacity");
@@ -100,10 +102,10 @@ describe("AdminCreateCommonsPage tests", () => {
         fireEvent.change(cowPriceField, { target: { value: "10" } });
         fireEvent.change(milkPriceField, { target: { value: "5" } });
         fireEvent.change(startDateField, { target: { value: "2022-03-05" } });
+        fireEvent.change(lastDateField, { target: { value: '3000-03-03' } })
         fireEvent.change(degradationRateField, { target: { value: "30.4" } });
         fireEvent.change(priceChangeField, { target: { value: "25" } });
         fireEvent.change(carryingCapacityField, { target: { value: "25" } });
-
         fireEvent.change(showLeaderboardField, { target: { value: true } });
         fireEvent.click(button);
 
@@ -119,7 +121,8 @@ describe("AdminCreateCommonsPage tests", () => {
             cowPrice: 10,
             priceChange: 25,
             milkPrice: 5,
-            startingDate: "2022-03-05T00:00:00.000Z", // [1]
+            startingDate: '2022-03-05T00:00:00.000Z',
+            lastDate: '3000-03-03T00:00:00.000Z',
             degradationRate: 30.4,
             carryingCapacity: 25,
             showLeaderboard: false,
@@ -137,7 +140,9 @@ describe("AdminCreateCommonsPage tests", () => {
                 <br />
                 name: My New Commons
                 <br />
-                startDate: 2022-03-05T00:00:00
+                startingDate: 2022-03-05T00:00:00
+                <br />
+                lastDate: 3000-01-01T00:00:00
                 <br />
                 cowPrice: 10
                 <br />

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.js
@@ -44,6 +44,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "id": 5,
                 "name": "Seths Common",
                 "startingDate": "2022-03-05",
+                "lastDate": "2022-03-25",
                 "startingBalance": 1200,
                 "cowPrice": 15,
                 "milkPrice": 10,
@@ -55,6 +56,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "id": 5,
                 "name": "Phill's Commons",
                 "startingDate": "2022-03-07",
+                "lastDate": "2022-06-06",
                 "startingBalance": 1400,
                 "cowPrice": 200,
                 "milkPrice": 5,
@@ -91,12 +93,14 @@ describe("AdminEditCommonsPage tests", () => {
             const cowPriceField = screen.getByLabelText(/Cow Price/);
             const milkPriceField = screen.getByLabelText(/Milk Price/);
             const startingDateField = screen.getByLabelText(/Starting Date/);
+            const lastDateField = screen.getByLabelText(/Last Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
             const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
 
             expect(nameField).toHaveValue("Seths Common");
             expect(startingDateField).toHaveValue("2022-03-05");
+            expect(lastDateField).toHaveValue("2022-03-25");
             expect(startingBalanceField).toHaveValue(1200);
             expect(cowPriceField).toHaveValue(15);
             expect(milkPriceField).toHaveValue(10);
@@ -121,12 +125,14 @@ describe("AdminEditCommonsPage tests", () => {
             const cowPriceField = screen.getByLabelText(/Cow Price/);
             const milkPriceField = screen.getByLabelText(/Milk Price/);
             const startingDateField = screen.getByLabelText(/Starting Date/);
+            const lastDateField = screen.getByLabelText(/Last Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
             const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
 
             expect(nameField).toHaveValue("Seths Common");
             expect(startingDateField).toHaveValue("2022-03-05");
+            expect(lastDateField).toHaveValue("2022-03-25");
             expect(startingBalanceField).toHaveValue(1200);
             expect(cowPriceField).toHaveValue(15);
             expect(milkPriceField).toHaveValue(10);
@@ -140,6 +146,7 @@ describe("AdminEditCommonsPage tests", () => {
 
             fireEvent.change(nameField, { target: { value: "Phill's Commons" } })
             fireEvent.change(startingDateField, { target: { value: "2022-03-07" } })
+            fireEvent.change(lastDateField, { target: { value: "2022-06-06" } })
             fireEvent.change(startingBalanceField, { target: { value: 1400 } })
             fireEvent.change(cowPriceField, { target: { value: 200 } })
             fireEvent.change(milkPriceField, { target: { value: 5 } })
@@ -161,6 +168,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "cowPrice": 200,
                 "milkPrice": 5,
                 "startingDate": "2022-03-07T00:00:00.000Z",
+                "lastDate": "2022-06-06T00:00:00.000Z",
                 "degradationRate": 40.3,
                 "carryingCapacity": 200,
                 "showLeaderboard": true,

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -110,10 +110,10 @@ public class CommonsController extends ApiController {
     updated.setMilkPrice(params.getMilkPrice());
     updated.setStartingBalance(params.getStartingBalance());
     updated.setStartingDate(params.getStartingDate());
+    updated.setLastDate(params.getLastDate());
     updated.setShowLeaderboard(params.getShowLeaderboard());
     updated.setDegradationRate(params.getDegradationRate());
     updated.setCarryingCapacity(params.getCarryingCapacity());
-    updated.setPriceChange(params.getPriceChange());
 
     if (params.getDegradationRate() < 0) {
       throw new IllegalArgumentException("Degradation Rate cannot be negative");
@@ -148,10 +148,10 @@ public class CommonsController extends ApiController {
         .milkPrice(params.getMilkPrice())
         .startingBalance(params.getStartingBalance())
         .startingDate(params.getStartingDate())
+        .lastDate(params.getLastDate())
         .degradationRate(params.getDegradationRate())
         .showLeaderboard(params.getShowLeaderboard())
         .carryingCapacity(params.getCarryingCapacity())
-        .priceChange(params.getPriceChange())
         .build();
 
     // throw exception for degradation rate
@@ -192,6 +192,8 @@ public class CommonsController extends ApiController {
         .totalWealth(joinedCommons.getStartingBalance())
         .numOfCows(0)
         .cowHealth(100)
+        .startingDate(joinedCommons.getStartingDate())
+        .lastDate(joinedCommons.getLastDate())
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -29,6 +29,7 @@ public class Commons
   private double milkPrice;
   private double startingBalance;
   private LocalDateTime startingDate;
+  private LocalDateTime lastDate;
   private double degradationRate;
   private boolean showLeaderboard;
   private int carryingCapacity;

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -6,8 +6,8 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Builder;
 import lombok.AccessLevel;
-
-
+import java.util.Date;
+import java.time.LocalDateTime;
 import javax.persistence.*;
 
 @Data
@@ -33,5 +33,13 @@ public class UserCommons {
   private int numOfCows;
 
   private double cowHealth;
-}
 
+  private LocalDateTime startingDate;
+
+  private LocalDateTime lastDate;
+
+  public boolean gameInProgress(){
+    boolean output = (startingDate.isBefore(LocalDateTime.now()) && lastDate.isAfter(LocalDateTime.now()));
+    return output;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -29,8 +29,8 @@ public class CreateCommonsParams {
   @NumberFormat
   private double startingBalance;
   @NumberFormat private double degradationRate;
-  @DateTimeFormat
-  private LocalDateTime startingDate;
+  @DateTimeFormat private LocalDateTime startingDate;
+  @DateTimeFormat private LocalDateTime lastDate;
   @Builder.Default
   private Boolean showLeaderboard = false; 
   @NumberFormat

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -64,18 +64,19 @@ public class CommonsControllerTests extends ControllerTestCase {
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void createCommonsTest() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime startDate = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime endDate = LocalDateTime.parse("3000-03-05T15:50:10");
 
     Commons commons = Commons.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(50.0)
         .showLeaderboard(false)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -83,11 +84,11 @@ public class CommonsControllerTests extends ControllerTestCase {
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(50.0)
         .showLeaderboard(false)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -113,18 +114,18 @@ public class CommonsControllerTests extends ControllerTestCase {
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void createCommonsTest_zeroDegradation() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
+    LocalDateTime startDate = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime endDate = LocalDateTime.parse("3000-03-05T15:50:10");
     Commons commons = Commons.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(0)
         .showLeaderboard(false)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -132,11 +133,11 @@ public class CommonsControllerTests extends ControllerTestCase {
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(0)
         .showLeaderboard(false)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -162,17 +163,18 @@ public class CommonsControllerTests extends ControllerTestCase {
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void createCommonsTest_withIllegalDegradationRate() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime startDate = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime endDate = LocalDateTime.parse("3000-03-05T15:50:10");
 
     Commons commons = Commons.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(-8.49)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -180,10 +182,10 @@ public class CommonsControllerTests extends ControllerTestCase {
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(-8.49)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -227,18 +229,19 @@ public class CommonsControllerTests extends ControllerTestCase {
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void updateCommonsTest() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime startDate = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime endDate = LocalDateTime.parse("3000-03-05T15:50:10");
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(50.0)
         .showLeaderboard(true)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     Commons commons = Commons.builder()
@@ -246,11 +249,11 @@ public class CommonsControllerTests extends ControllerTestCase {
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(50.0)
         .showLeaderboard(true)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -276,7 +279,6 @@ public class CommonsControllerTests extends ControllerTestCase {
     parameters.setCarryingCapacity(123);
     commons.setCarryingCapacity(parameters.getCarryingCapacity());
 
-
     requestBody = objectMapper.writeValueAsString(parameters);
 
     when(commonsRepository.findById(0L))
@@ -298,18 +300,19 @@ public class CommonsControllerTests extends ControllerTestCase {
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void updateCommonsTest_withDegradationRate_Zero() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime startDate = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime endDate = LocalDateTime.parse("3000-03-05T15:50:10");
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(8.49)
         .showLeaderboard(false)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     Commons commons = Commons.builder()
@@ -317,11 +320,11 @@ public class CommonsControllerTests extends ControllerTestCase {
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(8.49)
         .showLeaderboard(false)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -366,18 +369,19 @@ public class CommonsControllerTests extends ControllerTestCase {
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void updateCommonsTest_withIllegalDegradationRate() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime startDate = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime endDate = LocalDateTime.parse("3000-03-05T15:50:10");
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(8.49)
         .showLeaderboard(false)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     Commons commons = Commons.builder()
@@ -385,11 +389,11 @@ public class CommonsControllerTests extends ControllerTestCase {
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(8.49)
         .showLeaderboard(false)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -475,8 +479,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     Commons c = Commons.builder()
         .id(2L)
-        .name("test commons")
-        .cowPrice(100)
+        .name("Example Commons")
         .build();
 
     UserCommons uc = UserCommons.builder()
@@ -625,18 +628,19 @@ public class CommonsControllerTests extends ControllerTestCase {
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void deleteCommons_test_admin_exists() throws Exception {
-    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime startDate = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime endDate = LocalDateTime.parse("3000-03-05T15:50:10");
 
     Commons c = Commons.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
-        .startingDate(someTime)
+        .startingDate(startDate)
+        .lastDate(endDate)
         .degradationRate(50.0)
         .showLeaderboard(false)
         .carryingCapacity(100)
-        .priceChange(100)
         .build();
 
     when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -22,6 +22,7 @@ import org.springframework.http.MediaType;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import org.springframework.beans.factory.annotation.Autowired;
 
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,6 +41,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 
 @WebMvcTest(controllers = UserCommonsController.class)
 @AutoConfigureDataJpa
@@ -61,7 +64,9 @@ public class UserCommonsControllerTests extends ControllerTestCase {
   private ObjectMapper objectMapper;
 
   public static UserCommons dummyUserCommons(long id) {
-    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100);
+    LocalDateTime startDate = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime endDate = LocalDateTime.parse("3000-03-05T15:50:10");
+    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100, startDate, endDate);
     return userCommons;
   }
   @WithMockUser(roles = { "ADMIN" })

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/UserCommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/UserCommonsTests.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.happiercows.entities;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import edu.ucsb.cs156.happiercows.entities.User;
+import org.junit.jupiter.api.Test;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.time.LocalDateTime;
+
+public class UserCommonsTests {
+    LocalDateTime start = LocalDateTime.parse("2020-01-21T06:47:22.756");
+    LocalDateTime start2 = LocalDateTime.parse("2020-03-05T15:50:10");
+    LocalDateTime end = LocalDateTime.parse("3000-01-21T06:47:22.756");
+    LocalDateTime end2 = LocalDateTime.parse("3000-03-05T15:50:10");
+    @Test
+    void test_gameInProgressTrue() throws Exception {
+        assertEquals(true, UserCommons.builder().startingDate(start).lastDate(end).build().gameInProgress());
+    }
+    @Test
+    void test_gameInProgress_False_Not_Started() throws Exception {
+        assertEquals(false, UserCommons.builder().startingDate(end).lastDate(end2).build().gameInProgress());
+    }
+    @Test
+    void test_gameInProgress_False_Already_Ended() throws Exception {
+        assertEquals(false, UserCommons.builder().startingDate(start).lastDate(start2).build().gameInProgress());
+    }
+}


### PR DESCRIPTION
Copied over files from #59 that don't have anything to do with jobs. Screenshots + a longer description can be found at #59.

### Description from 59:

Details:
Based on Professor Conrad's https://github.com/ucsb-cs156/proj-happycows/issues/42#issue-1738786926 feature.

Description:
Before this PR, each commons had a start date, but no end date, and the start date didn't affect game play. In this PR, I added an end date to Commons and a start and end date to userCommons. I also added a gameInProgress() function to the userCommons entity that checks against LocalDateTime.now() and tested this function. Next, I added Last Date as a field on the AdminCreateCommonsPage/AdminEditCommonsPage form. 

Implementation of Professor Conrad's ideas:

- [x]  Add lastday date. (this is more clear than end date, since it indicates that the game ends at 11:59:59 on that day). Needs to be added to entity in backend, POST and PUT endpoints in backend, form in frontend, and adjusted on Create and Update pages.
- [x]  Add a function to the UserCommons entity (and tests for it) called gameInProgress() that returns true if today's date is >= start date, and <= end date. This could be it's own PR, with tests. Note that mocking "today's date" is possible; tricky, but possible.